### PR TITLE
Travis hosting fix: change beta builds on travis to use beta hosting target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
         project: index-of-knowledge
     - stage: deploy-v4-beta
       env:
-        - DEPLOY_TARGET=prod
+        - DEPLOY_TARGET=beta
       script: "./compile_v4.sh"
       deploy:
         skip_cleanup: true
@@ -38,7 +38,7 @@ jobs:
           branches:
             only:
               - develop
-        only: "hosting:prod"
+        only: "hosting:beta"
         project: index-of-knowledge
     - stage: deploy-scraper
       env:


### PR DESCRIPTION
Fix #25 hopefully. We can see if the build is successful to beta with Github actions output below.

Seems like a copy pasta fail since develop should be associated with hosting:beta from the firebase configs..

This allows all PRs and pushes to develop to be build on https://index-of-knowledge-beta.firebaseapp.com/