### PR TITLE
Travis codegen divergence fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
         project: index-of-knowledge
     - stage: deploy-v4-beta
       env:
-        - DEPLOY_TARGET=prod
+        - DEPLOY_TARGET=beta
       script: "./compile_v4.sh"
       deploy:
         skip_cleanup: true
@@ -38,7 +38,7 @@ jobs:
           branches:
             only:
               - develop
-        only: "hosting:prod"
+        only: "hosting:beta"
         project: index-of-knowledge
     - stage: deploy-scraper
       env:

--- a/push.sh
+++ b/push.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+#
+# This script executes at the end of Travis builds to master, 
+# and mainly exists to push up code generated in build steps
+# e.g. newly generated awesomelist in README.md
+# 
+# Note: Awesomelist only really matters in master branch, since 
+# that's what people see when they click into a repo by default, 
+# so we can hardcode the branch name master
+#
+
 setup_git() {
   git checkout $TRAVIS_BRANCH
   git config --global user.email "travis@travis-ci.org"
@@ -17,6 +27,19 @@ upload_files() {
   git push --quiet --set-upstream origin master
 }
 
+# XXX: potential race condition if origin/develop changes,
+# but we can just re-run manually
+fix_develop() {
+  git checkout develop
+  git rebase master
+  git push --quiet --set-upstream origin develop
+}
+
 setup_git
 commit_website_files
 upload_files
+
+# XXX: master gets new awesome-list via codegen
+# we need to rebase develop on master each time to prevent divergence
+fix_develop
+


### PR DESCRIPTION
Currently, new additions to `README.md` are generated by Travis based on the current contents of the IoK as hosted on the ID: rustielin.id.blockstack, each time a push happens to `master`. The changes aren't merged back with `develop`, so the branches diverge. This is a simple hacky fix that checkouts develop and rebases master after each push to master. There's a race condition that causes the rebase to fail, in which case we need manual push.