### PR TITLE
Prevent Travis from invoking other Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ node_js:
 - '8'
 stages:
 - name: deploy-v4
-  if: branch = master
+  if: branch = master AND sender != "Travis CI"
 - name: deploy-v4-beta
-  if: branch = develop
+  if: branch = develop AND sender != "Travis CI"
 - name: deploy-scraper
-  if: branch = master
+  if: branch = master AND sender != "Travis CI"
 - name: deploy-scraper-beta
-  if: branch = develop
+  if: branch = develop AND sender != "Travis CI"
 jobs:
   include:
     - stage: deploy-v4


### PR DESCRIPTION
Currently, when Travis pushes new generated awesome-lists, after pushes to `master`, this is registered as another commit that Travis runs new builds for. These new builds upload to Firebase hosting again, and fail to update the awesome-lists since there are no changes. This isn't harmful at all so long as another PR doesn't preempt it, so it's idempotent for the most part.

It's mainly for our sanity that Travis doesn't call Travis to make another Travis build.. :) 