### PR TITLE
[travis] skip compile and deploy steps if no changes, also bump node to v13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: node_js
 node_js:
-- '8'
+- '13'
 stages:
 - name: deploy-v4
   if: branch = master AND sender != "Travis CI" AND type IN (push)

--- a/compile_v4.sh
+++ b/compile_v4.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
-cd $TRAVIS_BUILD_DIR/v4
-npm install
-npm run lint && npm run build
+git diff-tree --name-only -r HEAD~1 | grep v4 && do_compile=1
+
+if [ -n "$do_compile" ]; then
+    cd $TRAVIS_BUILD_DIR/v4
+    npm install
+    npm run lint && npm run build
+else
+    echo "No changes, skipping build!"
+fi

--- a/deploy_v4.sh
+++ b/deploy_v4.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-npm install -g firebase-tools
-cd $TRAVIS_BUILD_DIR/v4
-echo "Deploying to only hosting:$DEPLOY_TARGET" 
-npm install
-npm run build
-firebase deploy --project index-of-knowledge --only hosting:$DEPLOY_TARGET --token $FIREBASE_TOKEN
+git diff-tree --name-only -r HEAD~1 | grep v4 && do_deploy=1
+
+if [ -n "$do_deploy" ]; then
+    npm install -g firebase-tools
+    cd $TRAVIS_BUILD_DIR/v4
+    echo "Deploying to only hosting:$DEPLOY_TARGET" 
+    npm install
+    npm run build
+    firebase deploy --project index-of-knowledge --only hosting:$DEPLOY_TARGET --token $FIREBASE_TOKEN
+else
+    echo "No changes, skipping deploy!"
+fi


### PR DESCRIPTION
Don't run v4 compile and deploy steps if git diff-tree doesn't show that we've changed v4 subdirectory.

Scraper in Travis is pretty flaky, so we might have to consider alternative flows. Hoping bump to node v13 fixes that though.