### PR TITLE
separate storage module with ipfs and blockstack

### DIFF
--- a/v4/README.md
+++ b/v4/README.md
@@ -8,6 +8,8 @@ https://index-of-knowledge.firebaseapp.com/
 
 To start as a dev, simply run the standard `npm install` and `npm run start` to launch in dev mode. Some auto-generated React docs below...
 
+We also provide two storage backends: Blockstack via Gaia, and IPFS via Pinata. Configuration will vary.
+
 ## old stuff below
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).

--- a/v4/package-lock.json
+++ b/v4/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "hello-blockstack",
-  "version": "0.0.0",
+  "name": "index-of-knowledge",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2101,6 +2101,37 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "axobject-query": {
       "version": "2.1.1",
@@ -4892,11 +4923,6 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
-    },
-    "dotenv": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
     },
     "dotenv-expand": {
       "version": "4.2.0",
@@ -11603,6 +11629,13 @@
         "webpack-dev-server": "3.2.1",
         "webpack-manifest-plugin": "2.0.4",
         "workbox-webpack-plugin": "4.2.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+          "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+        }
       }
     },
     "react-split": {

--- a/v4/package.json
+++ b/v4/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "axios": "^0.19.2",
     "blockstack": "^19.2.5",
     "cytoscape": "^3.13.0",
     "cytoscape-cola": "^2.3.0",

--- a/v4/src/App.jsx
+++ b/v4/src/App.jsx
@@ -7,6 +7,8 @@ import { UserSession } from 'blockstack';
 import Landing from './Landing';
 import SignedIn from './SignedIn';
 import Log from './log';
+import { STORAGE_TYPES } from './types';
+import { DEFL_STORAGE, DEFL_STORAGE_OPTIONS } from './constants';
 
 class App extends Component {
   static changeToGuestMode() {
@@ -16,40 +18,85 @@ class App extends Component {
     window.location.href = url;
   }
 
+  static parseParams() {
+    const par = new URLSearchParams(window.location.search);
+
+    /**
+     * Params parsing logic, mainly for configuring storage
+     * and related options
+     * */
+    let storage = DEFL_STORAGE;
+    let options = DEFL_STORAGE_OPTIONS;
+    if (par.has('storage')) {
+      switch (par.get('storage')) {
+        case STORAGE_TYPES.BLOCKSTACK:
+          storage = STORAGE_TYPES.BLOCKSTACK;
+          if (par.has('guest') && par.get('guest') === 'true') {
+            options.guest = true;
+            options.username = 'guest';
+          } else {
+            options.guest = false;
+          }
+          if (par.has('loaduser')) {
+            options.loaduser = par.get('loaduser');
+          }
+          break;
+        case STORAGE_TYPES.IPFS:
+          storage = STORAGE_TYPES.IPFS;
+          if (par.has('hash')) {
+            options.hash = par.get('hash');
+          }
+          break;
+        default:
+          storage = DEFL_STORAGE;
+          options = DEFL_STORAGE_OPTIONS;
+      }
+    }
+    return { storage, options };
+  }
+
   constructor() {
     super();
+
+    const { storage, options } = App.parseParams();
+    this.state = { storage, options };
     this.userSession = new UserSession();
-    const par = new URLSearchParams(window.location.search);
-    const guestMode = par.has('guest') && par.get('guest') === 'true';
-    this.state = {
-      guestMode,
-    };
-    Log.info('GUEST MODE?', guestMode);
+
+    Log.info(storage, options);
   }
 
   componentDidMount() {
-    const { guestMode } = this.state;
-    // moved from deprecated
+    const { storage, options } = this.state;
     const session = this.userSession;
-    if (!guestMode && !session.isUserSignedIn() && session.isSignInPending()) {
-      session.handlePendingSignIn()
-        .then((userData) => {
-          if (!userData.username) {
-            throw new Error('This app requires a username.');
-          }
-          window.location.href = '/';
-        });
+
+    // If we're using blockstack, get the username
+    if (storage === STORAGE_TYPES.BLOCKSTACK
+      && !('guest' in options)
+      && !('loaduser' in options)
+      && !options.guest
+      && !options.loaduser
+      && !session.isUserSignedIn()
+      && session.isSignInPending()) {
+      session.handlePendingSignIn().then((userData) => {
+        if (!userData.username) {
+          throw new Error('This app requires a username.');
+        }
+        this.setState({ options: { ...options, username: userData.username } });
+        window.location.href = '/';
+      });
     }
   }
 
   render() {
-    const { guestMode } = this.state;
+    const { storage, options } = this.state;
+    Log.trace('Re-render App.jsx:', storage, options);
     return (
       <div className="site-wrapper">
-        {guestMode || this.userSession.isUserSignedIn()
-          ? <SignedIn guestMode={guestMode} />
-          : <Landing guestModeHandler={App.changeToGuestMode} />
-        }
+        {storage === STORAGE_TYPES.IPFS || options.guest || this.userSession.isUserSignedIn() ? (
+          <SignedIn storage={storage} options={options} />
+        ) : (
+          <Landing guestModeHandler={App.changeToGuestMode} />
+        )}
       </div>
     );
   }

--- a/v4/src/IokText.jsx
+++ b/v4/src/IokText.jsx
@@ -14,7 +14,8 @@ import './styles/IokText.css';
 import {
   regroupCy, toggleDrawMode, toggleMeta, addNode, getNodesEdgesJson,
 } from './listen';
-import { GRAPH_FILENAME, NTYPE } from './constants';
+import { GRAPH_FILENAME } from './constants';
+import { NTYPE } from './types';
 
 class IokText extends Component {
   constructor(props) {

--- a/v4/src/NavBar.jsx
+++ b/v4/src/NavBar.jsx
@@ -1,39 +1,125 @@
 // eslint-disable-line
-import React from 'react';
+/* eslint-disable guard-for-in */
+import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { PropTypes } from 'prop-types';
+import { STORAGE_TYPES } from './types';
+import { DEFL_STORAGE, DEFL_STORAGE_OPTIONS } from './constants';
 import './styles/NavBar.css';
 
-const NavBar = function render(props) {
-  const {
-    username, loadName, changeLoadUser, signOut,
-  } = props;
-  return (
-    <nav className="navbar navbar-expand-md navbar-dark bg-blue fixed-top">
-      <Link className="navbar-brand" onClick={() => changeLoadUser(username)} to="/">Index of Knowledge</Link>
+class NavBar extends Component {
+  static paramsBuilder(options) {
+    let str = '/';
 
-      <ul className="navbar-nav mr-auto">
-        <li className="nav-item">
-          {/* <Link className="nav-link" to='/me'>{username}</Link> */}
-        </li>
-      </ul>
-      <p className="navbar-nav mr-auto">
-        {`Viewing ${loadName}'s IoK, logged in as ${username}`}
-      </p>
-      <button
-        type="button"
-        className="btn btn-primary"
-        onClick={signOut.bind(this)}
-      >
-        {`Sign ${username === 'guest' ? 'in' : 'out'}`}
-      </button>
-    </nav>
-  );
-};
+    // eslint-disable-next-line no-restricted-syntax
+    for (const key in options) {
+      if (str !== '') {
+        str += '&';
+      }
+      str += `${key}=${encodeURIComponent(options[key])}`;
+    }
+    return str;
+  }
+
+  static onHomeClick(storage, options, changeLoadUser) {
+    switch (storage) {
+      case STORAGE_TYPES.BLOCKSTACK:
+        changeLoadUser(options.username);
+        break;
+      case STORAGE_TYPES.IPFS:
+        window.location.href = NavBar.paramsBuilder(DEFL_STORAGE_OPTIONS);
+        break;
+      default:
+        break;
+    }
+  }
+
+  static greetingBuilder(storage, options) {
+    switch (storage) {
+      case STORAGE_TYPES.BLOCKSTACK:
+        return `Viewing ${options.loaduser}'s IoK, logged in as ${options.username}`;
+      case STORAGE_TYPES.IPFS:
+        return options.hash;
+      default:
+        return 'Hello';
+    }
+  }
+
+  static signOutBuilder(storage, options, signOutHandler) {
+    switch (storage) {
+      case STORAGE_TYPES.BLOCKSTACK:
+        return (
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={signOutHandler}
+          >
+          Sign
+            {options.username === 'guest' ? ' in' : ' out'}
+
+          </button>
+        );
+      case STORAGE_TYPES.IPFS:
+        return '';
+      default:
+        return 'Hello';
+    }
+  }
+
+  static selectStorageBuilder(storage) {
+    switch (storage) {
+      case STORAGE_TYPES.BLOCKSTACK:
+        return (
+          <button
+            type="button"
+            className="btn btn-info btn-lg btn-util"
+            onClick={() => { window.location.href = '/?storage='.concat(STORAGE_TYPES.IPFS); }}
+          >
+          Try IPFS!
+          </button>
+        );
+      case STORAGE_TYPES.IPFS:
+        return (
+          <button
+            type="button"
+            className="btn btn-info btn-lg btn-util"
+            onClick={() => { window.location.href = '/?storage='.concat(STORAGE_TYPES.BLOCKSTACK); }}
+          >
+          Try Blockstack!
+          </button>
+        );
+      default:
+        return 'Hello';
+    }
+  }
+
+
+  render() {
+    const {
+      storage, options, changeLoadUser, signOut,
+    } = this.props;
+    return (
+      <nav className="navbar navbar-expand-md navbar-dark bg-blue fixed-top">
+        <Link className="navbar-brand" onClick={() => NavBar.onHomeClick(storage, options, changeLoadUser)} to="/">Index of Knowledge</Link>
+
+        <ul className="navbar-nav mr-auto">
+          <li className="nav-item">
+            {NavBar.greetingBuilder(storage, options)}
+          </li>
+        </ul>
+        <p className="navbar-nav mr-auto">
+          {}
+        </p>
+        {NavBar.selectStorageBuilder(storage)}
+        {NavBar.signOutBuilder(storage, options, signOut.bind(this))}
+      </nav>
+    );
+  }
+}
 
 NavBar.defaultProps = {
-  username: 'default',
-  loadName: 'default',
+  storage: DEFL_STORAGE,
+  options: DEFL_STORAGE_OPTIONS,
   // XXX: replace these alerts
   // eslint-disable-next-line no-alert
   changeLoadUser: () => alert('ERROR: changeLoadUser() invalid'),
@@ -42,8 +128,9 @@ NavBar.defaultProps = {
 };
 
 NavBar.propTypes = {
-  username: PropTypes.string,
-  loadName: PropTypes.string,
+  storage: PropTypes.string,
+  // eslint-disable-next-line react/forbid-prop-types
+  options: PropTypes.object,
   changeLoadUser: PropTypes.func,
   signOut: PropTypes.func,
 };

--- a/v4/src/constants.js
+++ b/v4/src/constants.js
@@ -1,9 +1,16 @@
 // eslint-disable-line
 import { AppConfig } from 'blockstack';
+import { STORAGE_TYPES } from './types';
 
 export const appConfig = new AppConfig(['store_write', 'publish_data']);
 
 export const GRAPH_FILENAME = 'graph.json';
+
+export const DEFL_STORAGE = STORAGE_TYPES.IPFS;
+
+export const DEFL_STORAGE_OPTIONS = {
+  hash: 'QmWm3A6EdXYD12eaEjADs7iPnraEaYmK788QEHumQZ7yrH',
+};
 
 export const IOKS = [
   {
@@ -15,17 +22,6 @@ export const IOKS = [
     app: 'https://index-of-knowledge-beta.firebaseapp.com/?loaduser=rustielintest.id.blockstack',
   },
 ];
-
-/** Types of nodes on the graph */
-export const NTYPE = {
-  TOPIC: 1,
-  RESO: 2,
-};
-/** Types of resources on the graph */
-export const RTYPE = {
-  DESC: 1,
-  LINK: 4,
-};
 
 // TODO: change all the id's since cytoscape will crash if collision
 // TODO: change all id's to hashes

--- a/v4/src/storage/blockstack.js
+++ b/v4/src/storage/blockstack.js
@@ -1,0 +1,23 @@
+// eslint-disable-line
+import Log from '../log';
+
+const TAG = 'storage.blockstack';
+
+const loadBlockstackGraph = (userSession, loadUsername, filename, onSuccess, onError) => {
+  Log.info('GOT FUNCTIONS', onSuccess, onError);
+  Log.info(TAG, 'Loading', loadUsername, "'s data");
+  const options = { decrypt: false, username: loadUsername };
+  userSession.getFile(filename, options)
+    .then((content) => {
+      if (content && content.length > 0) {
+        const graph = JSON.parse(content);
+        onSuccess(graph);
+      } else {
+        onError();
+      } // deal with fail and err as same
+    }).catch((err) => {
+      onError(err);
+    });
+};
+
+export default loadBlockstackGraph;

--- a/v4/src/storage/blockstack.js
+++ b/v4/src/storage/blockstack.js
@@ -1,13 +1,14 @@
 // eslint-disable-line
 import Log from '../log';
+import { GRAPH_FILENAME } from '../constants';
 
 const TAG = 'storage.blockstack';
 
-const loadBlockstackGraph = (userSession, loadUsername, filename, onSuccess, onError) => {
+export const loadBlockstackGraph = (userSession, loadUsername, onSuccess, onError) => {
   Log.info('GOT FUNCTIONS', onSuccess, onError);
   Log.info(TAG, 'Loading', loadUsername, "'s data");
   const options = { decrypt: false, username: loadUsername };
-  userSession.getFile(filename, options)
+  userSession.getFile(GRAPH_FILENAME, options)
     .then((content) => {
       if (content && content.length > 0) {
         const graph = JSON.parse(content);
@@ -20,4 +21,11 @@ const loadBlockstackGraph = (userSession, loadUsername, filename, onSuccess, onE
     });
 };
 
-export default loadBlockstackGraph;
+export const saveBlockstackGraph = (graph, userSession) => {
+  Log.info(TAG, 'SAVING...', graph);
+  userSession
+    .putFile(GRAPH_FILENAME, JSON.stringify(graph), { encrypt: false })
+    .finally(() => {
+      Log.info('Saved');
+    });
+};

--- a/v4/src/storage/ipfs.js
+++ b/v4/src/storage/ipfs.js
@@ -1,0 +1,17 @@
+// eslint-disable-line
+import Log from '../log';
+
+const TAG = 'storage.ipfs';
+const base = 'https://ipfs.io/ipfs/';
+
+const loadIPFSGraph = (hash, onSuccess, onError) => {
+  Log.info(TAG, 'Loading from IPFS', hash);
+  const url = base + hash;
+  fetch(url).then((response) => response.json()).then((data) => {
+    onSuccess(data);
+  }).catch((err) => {
+    onError(err);
+  });
+};
+
+export default loadIPFSGraph;

--- a/v4/src/storage/ipfs.js
+++ b/v4/src/storage/ipfs.js
@@ -3,8 +3,9 @@ import Log from '../log';
 
 const TAG = 'storage.ipfs';
 const base = 'https://ipfs.io/ipfs/';
+const pinataProxy = 'https://us-central1-index-of-knowledge.cloudfunctions.net/storeGraph';
 
-const loadIPFSGraph = (hash, onSuccess, onError) => {
+export const loadIPFSGraph = (hash, onSuccess, onError) => {
   Log.info(TAG, 'Loading from IPFS', hash);
   const url = base + hash;
   fetch(url).then((response) => response.json()).then((data) => {
@@ -14,4 +15,15 @@ const loadIPFSGraph = (hash, onSuccess, onError) => {
   });
 };
 
-export default loadIPFSGraph;
+export const saveIPFSGraph = (graph) => {
+  const requestOptions = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(graph),
+  };
+  Log.info("GRAPH", graph)
+  fetch(pinataProxy, requestOptions)
+    .then((response) => {Log.info("RESPONSE", response); return response.json()})
+    .then((data) => alert(data.IpfsHash))
+    .catch((err) => Log.error(err));
+};

--- a/v4/src/types.js
+++ b/v4/src/types.js
@@ -1,0 +1,19 @@
+// eslint-disable-line
+
+/** Types of storage backends */
+export const STORAGE_TYPES = {
+  BLOCKSTACK: 'blockstack',
+  IPFS: 'ipfs',
+};
+
+/** Types of nodes on the graph */
+export const NTYPE = {
+  TOPIC: 1,
+  RESO: 2,
+};
+
+/** Types of resources on the graph */
+export const RTYPE = {
+  DESC: 1,
+  LINK: 4,
+};


### PR DESCRIPTION
Move storage to its own module and separate with success and error callbacks. Support for IPFS and  Blockstack backends. Fixed params parsing a bit so we now accept `storage` and storage-specific options e.g. loaduser and hash.

Example:

IPFS: https://index-of-knowledge-beta.firebaseapp.com/?storage=ipfs&hash=QmfU35zRkphCAjB8K8aZsfnkrztMAbCdjpSue5b3fcMr3t

Blockstack: https://index-of-knowledge-beta.firebaseapp.com/?storage=blockstack&loaduser=rustielin.id.blockstack&guest=true