### PR TITLE
[storage] implement autosave cache

### DIFF
--- a/v4/src/App.jsx
+++ b/v4/src/App.jsx
@@ -26,7 +26,7 @@ class App extends Component {
      * and related options
      * */
     let storage = DEFL_STORAGE;
-    let options = DEFL_STORAGE_OPTIONS;
+    let options = JSON.parse(JSON.stringify(DEFL_STORAGE_OPTIONS));
     if (par.has('storage')) {
       switch (par.get('storage')) {
         case STORAGE_TYPES.BLOCKSTACK:
@@ -49,7 +49,7 @@ class App extends Component {
           break;
         default:
           storage = DEFL_STORAGE;
-          options = DEFL_STORAGE_OPTIONS;
+          options = JSON.parse(JSON.stringify(DEFL_STORAGE_OPTIONS));
       }
     }
     return { storage, options };

--- a/v4/src/SignedIn.jsx
+++ b/v4/src/SignedIn.jsx
@@ -54,6 +54,9 @@ class SignedIn extends Component {
   constructor(props) {
     super(props);
     const { storage, options } = this.props;
+    Log.info('storage/options');
+    Log.info(storage);
+    Log.info(options);
 
     this.userSession = new UserSession({ appConfig });
 
@@ -156,12 +159,14 @@ class SignedIn extends Component {
       // e.g. loading from a cached IoK copied from someone's blockstack storage
       if ((cached.storage === storage
         && JSON.stringify(cached.options) === JSON.stringify(options))) {
+        Log.info('Load request cache');
         this.onSuccessLoadGraph(cached.graph);
         return;
       }
       // if we're loading the default graph, check cache first
       if (storage === DEFL_STORAGE
         && JSON.stringify(options) === JSON.stringify(DEFL_STORAGE_OPTIONS)) {
+        Log.info('Load DEFL request cache');
         this.onSuccessLoadGraph(cached.graph);
         return;
       }

--- a/v4/src/listen.js
+++ b/v4/src/listen.js
@@ -44,6 +44,10 @@ export const getNodesEdgesJson = (cy) => {
   const j = cy.json();
   const { nodes } = j.elements;
   const { edges } = j.elements;
+  if (!nodes || !edges) {
+    return { nodes: [], edges: [] };
+    // return null; // XXX: this might be easier to propagate errors
+  }
   for (let i = 0; i < nodes.length; i += 1) {
     nodes[i] = { data: nodes[i].data };
   }

--- a/v4/src/storage/cache.js
+++ b/v4/src/storage/cache.js
@@ -1,0 +1,69 @@
+// eslint-disable-line
+import Log from '../log';
+
+const TAG = 'storage.localstorage';
+
+/**
+ * NOTE: this only allows us to cache one graph at a time now.
+ * While this might be easier to understand to the end user,
+ * we could also allow caching for each (storage, options), but that might get confusing
+ */
+const KEY = 'localgraph';
+const STORAGE_KEY = 'storagetype';
+const OPTIONS_KEY = 'storageoptions';
+
+/**
+ * Loads graph, storage, and options (metadata) from cache in localstorage
+ * only if cache exists and there are nodes and edges to populate
+ * @param {*} onError
+ */
+export const loadCache = (onError) => {
+  Log.info(TAG, 'Loading from localstorage');
+  const storedGraph = localStorage.getItem(KEY);
+  const storage = localStorage.getItem(STORAGE_KEY);
+  const storedOptions = localStorage.getItem(OPTIONS_KEY);
+  try {
+    if (storedGraph && storage && storedOptions) {
+      const graph = JSON.parse(storedGraph);
+      if (graph.elements !== null
+        && graph.elements.nodes.length > 0 && graph.elements.edges.length > 0) {
+        const options = JSON.parse(storedOptions);
+        Log.info(TAG, 'Got from graph from localstorage');
+        Log.info(TAG, graph);
+        return { graph, storage, options };
+      }
+      onError('cached graph is empty, skipping');
+    }
+    onError('cache is empty');
+  } catch (err) {
+    onError(err);
+  }
+  return {};
+};
+
+/**
+ * Saves graph, storage, options to cache in localstorage
+ * @param {*} graph 
+ * @param {*} storage 
+ * @param {*} options 
+ */
+export const saveCache = (graph, storage, options) => {
+  // Log.info(TAG, 'Saving graph to localstorage');
+  // Log.info(TAG, graph);
+  try {
+    const graphStr = JSON.stringify(graph);
+    localStorage.setItem(KEY, graphStr);
+    localStorage.setItem(STORAGE_KEY, storage);
+    const optionsStr = JSON.stringify(options);
+    localStorage.setItem(OPTIONS_KEY, optionsStr);
+    Log.info(TAG, 'localstorage save successful');
+  } catch (err) {
+    // pass
+  }
+};
+
+export const wipeCache = () => {
+  localStorage.removeItem(KEY);
+  localStorage.removeItem(STORAGE_KEY);
+  localStorage.removeItem(OPTIONS_KEY);
+};

--- a/v4/src/storage/cache.js
+++ b/v4/src/storage/cache.js
@@ -30,6 +30,8 @@ export const loadCache = (onError) => {
         const options = JSON.parse(storedOptions);
         Log.info(TAG, 'Got from graph from localstorage');
         Log.info(TAG, graph);
+        Log.info(TAG, storage);
+        Log.info(TAG, options);
         return { graph, storage, options };
       }
       onError('cached graph is empty, skipping');

--- a/v4/src/storage/ipfs.js
+++ b/v4/src/storage/ipfs.js
@@ -15,7 +15,7 @@ export const loadIPFSGraph = (hash, onSuccess, onError) => {
   });
 };
 
-export const saveIPFSGraph = (graph) => {
+export const saveIPFSGraph = (graph, onHashChange) => {
   const requestOptions = {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -24,6 +24,6 @@ export const saveIPFSGraph = (graph) => {
   Log.info("GRAPH", graph)
   fetch(pinataProxy, requestOptions)
     .then((response) => {Log.info("RESPONSE", response); return response.json()})
-    .then((data) => alert(data.IpfsHash))
+    .then((data) => onHashChange(data.IpfsHash))
     .catch((err) => Log.error(err));
 };


### PR DESCRIPTION
Implements a new storage provider for cache in browser localStorage. When user loads into the IoK webapp, they request a remote IoK based on `storage` and storage `options`. e.g. `storage=ipfs` and `options` being a payload `{hash=QmWm3A6EdXYD12eaEjADs7iPnraEaYmK788QEHumQZ7yrH}`. Cache is only loaded if it matches the user request, or if the user request is all DEFL.

## Test Plan

Deployed in personal Firebase hosting environment: https://iok-rustie.firebaseapp.com
You might have to clear your browser cache for this site if you've visited recently, or visit in incognito

DEFL case:
* load webapp at the base URL with no params, loading in default IoK configuration
* make a few changes, add nodes, draw edges
* don't save, and refresh the page/open in new window/tab

Request case:
* load webapp with certain `storage` and `options` requirements, e.g. https://iok-rustie.firebaseapp.com/?storage=ipfs&hash=QmQWkph5y3tQzETp4QWJ6ByQ9MKQnMQLQeQxw2RocvTZaz
* repeat previous steps above

## Note

We only store a single copy of the graph in cache according to set keys. We can cache more, keyed on `(storage, options)` tuple, but that might get confusing for user.

Resolves #76 