### PR TITLE
[refactor] clean up graph data format

### DIFF
--- a/src/iok/README.md
+++ b/src/iok/README.md
@@ -5,4 +5,33 @@ Main IoK python utils library.
 * `constants` contains some constants for generating Awesome Lists
 * `meta` contains meta-objects used by the IoK to represent Awesome Lists, Graphs, etc
 * `types` contains some reusable types
-* 
+  
+
+## Graph Data Format
+
+```
+{
+    ...
+    nodes: [
+        data: {
+            id: node_type == TOPIC ? sha256(data.name) : sha256(data.text || data.link),
+            data: { # if node_type == RESOURCE
+                text: <node_text>,
+                link: <node_link>
+            },
+            name: <node_name>, # if node_type == TOPIC
+            node_type: <node_type>,
+            resource_type: <resource_type>, # if node_type == RESOURCE
+            meta: ...,
+        }
+    ],
+    edges: [
+        data: {
+            id: sha256(source || target),
+            source: <source_node_id>,
+            target: <target_node_id>,
+            meta: ...,
+        }
+    ]
+}
+```

--- a/src/iok/meta.py
+++ b/src/iok/meta.py
@@ -51,10 +51,9 @@ class KnowledgeGraph:
 
         for x in dat["nodes"]:
             x["data"] = x.copy()
-            if x["node_type"] == NodeType.TOPIC:
-                del x["name"]
-            elif x["node_type"] == NodeType.RESOURCE:
+            if x["node_type"] == NodeType.RESOURCE:
                 del x["resource_type"]
+            del x["name"]
             del x["node_type"]
             del x["id"]
 
@@ -146,7 +145,11 @@ class KnowledgeGraph:
             self.graph.add_node(id, name=name, node_type=node_type)
         elif node_type == NodeType.RESOURCE:
             self.graph.add_node(
-                id, data=data, resource_type=resource_type, node_type=node_type
+                id,
+                name=f"res-{id[:7]}",  # XXX: get rid of this eventually
+                data=data,
+                resource_type=resource_type,
+                node_type=node_type,
             )
 
         return id

--- a/src/iok/meta.py
+++ b/src/iok/meta.py
@@ -5,6 +5,8 @@ import random
 import string
 from typing import Optional
 import re
+import hashlib
+import uuid
 import networkx as nx
 import matplotlib.pyplot as plt
 from networkx.readwrite import json_graph
@@ -26,11 +28,41 @@ class KnowledgeGraph:
             self.graph = nx.DiGraph()
             self.read_from_json_obj(obj)
         # create new one if not
+        self.graph = nx.DiGraph()
 
     def write_graph(self, filename):
         """For debugging mostly, write graph to png"""
         nx.draw(self.graph, with_labels=True)
         plt.savefig(filename)
+
+    def write_to_json(self, filename=""):
+        """
+        Write the graph to JSON file according to cytoscape format.
+        Returns if no filename provided.
+        """
+        dat = json_graph.node_link_data(self.graph)
+        # wrap everything in a "data" field
+        dat["edges"] = dat.pop("links")
+        for x in dat["edges"]:
+            x["data"] = x.copy()
+            del x["source"]
+            del x["target"]
+            del x["id"]
+
+        for x in dat["nodes"]:
+            x["data"] = x.copy()
+            if x["node_type"] == NodeType.TOPIC:
+                del x["name"]
+            elif x["node_type"] == NodeType.RESOURCE:
+                del x["resource_type"]
+            del x["node_type"]
+            del x["id"]
+
+        if filename:
+            with open(filename, "w") as f:
+                json.dump(dat, f)
+        else:
+            return dat
 
     def read_from_json_obj(self, obj):
         """Reads graph from JSON object"""
@@ -49,7 +81,7 @@ class KnowledgeGraph:
             if "name" in dat:
                 name = dat["name"]
 
-            self.add_knowledge_node(
+            self._add_knowledge_node(
                 dat["id"],
                 NodeType(dat["node_type"]),
                 name=name,
@@ -67,23 +99,57 @@ class KnowledgeGraph:
             elements = json.load(f)
             self.read_from_json_obj(elements)
 
-    def add_knowledge_node(
+    def add_edge(self, src_id: str, dst_id: str, id: str = ""):
+        if not id:
+            m = hashlib.sha256()
+            m.update(src_id.encode())
+            m.update(dst_id.encode())
+            id = m.hexdigest()
+        self.graph.add_edge(src_id, dst_id, id=id)
+        return id
+
+    def add_topic_node(self, name, id: str = "") -> str:
+        if not id:
+            m = hashlib.sha256()
+            m.update(name.encode())
+            id = m.hexdigest()
+        return self._add_knowledge_node(NodeType.TOPIC, id=id, name=name)
+
+    def add_resource_node(
         self,
-        id: str,
+        text: str,
+        link: str = "",
+        id: str = "",
+        resource_type: Optional[ResourceType] = ResourceType.DESCRIPTION,
+    ) -> str:
+        if not id:
+            m = hashlib.sha256()
+            m.update(text.encode())
+            m.update(link.encode())
+            id = m.hexdigest()
+        data = {"text": text, "link": link}
+        return self._add_knowledge_node(
+            NodeType.RESOURCE, id=id, data=data, resource_type=resource_type
+        )
+
+    def _add_knowledge_node(
+        self,
         node_type: NodeType,
-        name=None,
-        data=None,
+        id: str = "",
+        name: str = None,
+        data: str = None,
         resource_type: Optional[ResourceType] = None,
-    ):
+    ) -> str:
         self.graph.add_node(id)
-        node = self.graph.nodes[id]
-        node["node_type"] = node_type
-        if resource_type:
-            node["resource_type"] = resource_type
-        if data:
-            node["data"] = data
-        if name:
-            node["name"] = name
+
+        if node_type == NodeType.TOPIC:
+            self.graph.add_node(id, name=name, node_type=node_type)
+        elif node_type == NodeType.RESOURCE:
+            self.graph.add_node(
+                id, data=data, resource_type=resource_type, node_type=node_type
+            )
+
+        return id
 
     def get_graph(self):
         return self.graph

--- a/src/iok/tests/test_knowledge_graph.py
+++ b/src/iok/tests/test_knowledge_graph.py
@@ -1,0 +1,79 @@
+from iok.meta import KnowledgeGraph
+from iok.types import ResourceType, NodeType
+
+
+def test_init() -> None:
+    """KnowledgeGraph loads empty by default"""
+    kg = KnowledgeGraph()
+    g = kg.get_graph()
+    assert len(g.nodes) == 0
+    assert len(g.edges) == 0
+
+
+def test_add_topic_node() -> None:
+    kg = KnowledgeGraph()
+    node_id = kg.add_topic_node("Bitcoin")
+    assert node_id
+    node_id2 = kg.add_topic_node("Bifcoin")
+    assert node_id2
+    assert node_id2 != node_id
+
+    # force a collision
+    node_id3 = kg.add_topic_node("Bitcoin CLONE", id=node_id)
+    assert node_id == node_id3
+
+
+def test_add_resource_node() -> None:
+    kg = KnowledgeGraph()
+    resource_id = kg.add_resource_node(
+        "Bitcoin desc", resource_type=ResourceType.DESCRIPTION
+    )
+    assert resource_id
+
+    resource_id2 = kg.add_resource_node(
+        "Bitcoin link", link="http://fakelink.bitcoin", resource_type=ResourceType.PAPER
+    )
+    assert resource_id2
+    assert resource_id != resource_id2
+
+
+def test_write_to_json() -> None:
+    kg = KnowledgeGraph()
+    node_name = "bitcoin"
+    node_id = kg.add_topic_node(node_name)
+
+    node_name2 = "bitcoin2"
+    node_id2 = kg.add_topic_node(node_name2)
+
+    resource = "bitcoin description"
+    resource_id = kg.add_resource_node(resource)
+
+    edge_id = kg.add_edge(node_id, node_id2)
+    j = kg.write_to_json()
+    print(j)  # if pytest fails, we'll see the output
+
+    assert len(j["nodes"]) == 3
+    assert len(j["edges"]) == 1
+
+    assert [
+        x
+        for x in j["nodes"]
+        if x["data"]["node_type"] == NodeType.TOPIC
+        and x["data"]["name"] == node_name
+        and x["data"]["id"] == node_id
+    ]
+    assert [
+        x
+        for x in j["nodes"]
+        if x["data"]["node_type"] == NodeType.TOPIC
+        and x["data"]["name"] == node_name2
+        and x["data"]["id"] == node_id2
+    ]
+    assert [x for x in j["nodes"] if x["data"]["node_type"] == NodeType.RESOURCE]
+    assert [
+        x
+        for x in j["edges"]
+        if x["data"]["source"] == node_id
+        and x["data"]["target"] == node_id2
+        and x["data"]["id"] == edge_id
+    ]

--- a/src/mdscraper/md_scrape.py
+++ b/src/mdscraper/md_scrape.py
@@ -50,8 +50,11 @@ class Scope:
         cleaned_line = line
         if match != r"^[A-Za-z]":
             cleaned_line = re.sub(match, "", line).strip()
+        m = sha256()
         if match in TOPICS:
+            m.update(cleaned_line.encode())
             dat = {"name": cleaned_line, "node_type": 1}
+            node_id = m.hexdigest()
         elif match in RESOURCES:
             link_if_link = self.get_link(cleaned_line)
             if link_if_link:
@@ -69,9 +72,11 @@ class Scope:
                     "node_type": 2,
                     "resource_type": 1,
                 }
+            m.update(dat["data"]["text"].encode())
+            m.update(dat["data"]["link"].encode())
+            node_id = m.hexdigest()
 
-        dats = json.dumps(dat).encode("utf-8")
-        dat["id"] = sha256(dats).hexdigest()
+        dat["id"] = node_id
         if "name" not in dat:
             dat["name"] = "res-" + dat["id"][:10]
         return {"data": dat}

--- a/src/mdscraper/md_scrape.py
+++ b/src/mdscraper/md_scrape.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 import networkx as nx
-from networkx.readwrite import json_graph
+from iok.meta import KnowledgeGraph
+from iok.types import ResourceType, NodeType
 import re
 import requests
 import matplotlib.pyplot as plt
@@ -22,17 +23,23 @@ RESOURCES = {r"^[A-Za-z]", r"^[*-]"}
 
 
 class Scope:
-    def __init__(self, match: str, line: str):
+    def __init__(self, match: str, line: str, graph: KnowledgeGraph):
         self.match = match
-        self.node = self.build_node_obj(line, match)
+        self.graph = graph
+        self.build_node_obj(line, match)
 
     def get_id(self):
-        return self.node["data"]["id"]
+        return self.id
 
-    def get_name(self):
-        return self.node["data"]["name"]
+    def _get_name(self):
+        """XXX: for debug only, gets the name of the underlying node"""
+        return self.graph.get_graph().nodes[self.id]["name"]
 
-    def get_link(self, line):
+    def _get_data(self):
+        """XXX: for debug only, gets the data of the underlying node"""
+        return self.graph.get_graph().nodes[self.id]["data"]
+
+    def _get_link(self, line):
         """Returns link text and link of parsed markdown link, if regex matched"""
         match = re.search(r"(?:__|[*#])|\[(.*?)\]\((.*?)\)", line)
         if match:
@@ -52,34 +59,21 @@ class Scope:
             cleaned_line = re.sub(match, "", line).strip()
         m = sha256()
         if match in TOPICS:
-            m.update(cleaned_line.encode())
-            dat = {"name": cleaned_line, "node_type": 1}
-            node_id = m.hexdigest()
+            node_id = self.graph.add_topic_node(cleaned_line)
         elif match in RESOURCES:
-            link_if_link = self.get_link(cleaned_line)
+            link_if_link = self._get_link(cleaned_line)
             if link_if_link:
                 text, link = link_if_link
-                # TODO: borrow enums from scraper/iok.py, into utils module
                 # TODO: do something about not inferring resource_type 2 for links...
-                dat = {
-                    "data": {"text": text, "link": link},
-                    "node_type": 2,
-                    "resource_type": 2,
-                }
+                node_id = self.graph.add_resource_node(
+                    text, link=link, resource_type=ResourceType.ARTICLE
+                )
             else:
-                dat = {
-                    "data": {"text": cleaned_line, "link": ""},
-                    "node_type": 2,
-                    "resource_type": 1,
-                }
-            m.update(dat["data"]["text"].encode())
-            m.update(dat["data"]["link"].encode())
-            node_id = m.hexdigest()
+                node_id = self.graph.add_resource_node(
+                    cleaned_line, resource_type=ResourceType.DESCRIPTION
+                )
 
-        dat["id"] = node_id
-        if "name" not in dat:
-            dat["name"] = "res-" + dat["id"][:10]
-        return {"data": dat}
+        self.id = node_id
 
 
 def cmp_hierarchy(s1: str, s2: str) -> int:
@@ -112,21 +106,15 @@ def match_hierarchy(line: str) -> str:
     return ""
 
 
-def update_scopes(match: str, line: str, scopes: list, graph: nx.DiGraph) -> list:
+def update_scopes(match: str, line: str, scopes: list, graph: KnowledgeGraph) -> list:
     """
     Update the scopes and add a new node to graph
     """
     scopes_cpy = scopes.copy()
 
-    # build the node
-    new_scope = Scope(match, line)
+    # build the node and add to graph
+    new_scope = Scope(match, line, graph)
     id = new_scope.get_id()
-
-    # add the node to graph
-    graph.add_node(id)
-    node = graph.nodes[id]
-    for k, v in new_scope.node.items():
-        node[k] = v
 
     # connect
     if scopes_cpy:
@@ -136,7 +124,7 @@ def update_scopes(match: str, line: str, scopes: list, graph: nx.DiGraph) -> lis
     return scopes_cpy
 
 
-def match_line(match: str, line: str, scopes: list, graph: nx.DiGraph) -> list:
+def match_line(match: str, line: str, scopes: list, graph: KnowledgeGraph) -> list:
     """
     Based on the current scope (list of regex by increasing specificity), add the current matched line
     to the graph by either branching or continuing the current branch 
@@ -151,7 +139,7 @@ def match_line(match: str, line: str, scopes: list, graph: nx.DiGraph) -> list:
 
     # peek the end
     end_scope = scopes_cpy[-1]
-    end_match, end_node = end_scope.match, end_scope.node
+    end_match = end_scope.match
 
     # determine whether to continue or branch
     cmped = cmp_hierarchy(match, end_match)
@@ -166,14 +154,14 @@ def match_line(match: str, line: str, scopes: list, graph: nx.DiGraph) -> list:
 
 
 # returns the graph for debugging
-def main(link: str) -> nx.DiGraph:
+def main(link: str) -> KnowledgeGraph:
 
     f = requests.get(link)
     text = f.text
     textlines = text.splitlines()
 
     scopes = []
-    graph = nx.DiGraph()
+    graph = KnowledgeGraph(0)
     for line in textlines:
         match = match_hierarchy(line)
         scopes = match_line(match, line, scopes, graph)
@@ -194,18 +182,6 @@ if __name__ == "__main__":
     g = main(link)
 
     # draw to file for debugging
-    nx.draw(g, with_labels=True)
-    plt.savefig(GRAPH_FILE)
+    g.write_graph(GRAPH_FILE)
 
-    # write to json file too
-    dat = json_graph.node_link_data(g)
-    # making it a format cytoscape likes...
-    dat["edges"] = dat.pop("links")
-    # wrap everything in a "data" key...
-    for x in dat["edges"]:
-        x["data"] = x.copy()
-        x["data"]["id"] = uuid.uuid1().hex
-        del x["source"]
-        del x["target"]
-    with open(JSON_FILE, "w") as f:
-        json.dump(dat, f)
+    g.write_to_json(JSON_FILE)

--- a/src/mdscraper/tests/test_md_scrape.py
+++ b/src/mdscraper/tests/test_md_scrape.py
@@ -1,4 +1,5 @@
 from ..md_scrape import cmp_hierarchy, Scope
+from iok.meta import KnowledgeGraph
 
 
 def test_cmp_hierarchy() -> None:
@@ -18,12 +19,13 @@ def test_cmp_hierarchy() -> None:
 
 
 def test_scope() -> None:
-    scope = Scope(r"^###", "### Bitcoin")
-    assert scope.get_name() == "Bitcoin"
+    kg = KnowledgeGraph()
+    scope = Scope(r"^###", "### Bitcoin", kg)
+    assert scope._get_name() == "Bitcoin"
 
     test_text = "Script - Bitcoin Wiki"
     test_link = "https://en.bitcoin.it/wiki/Script"
-    scope = Scope(r"^[*-]", f"* [{test_text}]({test_link})")
-    print(scope.node)
-    assert scope.node["data"]["data"]["text"] == test_text
-    assert scope.node["data"]["data"]["link"] == test_link
+    scope = Scope(r"^[*-]", f"* [{test_text}]({test_link})", kg)
+    data = scope._get_data()
+    assert data["text"] == test_text
+    assert data["link"] == test_link


### PR DESCRIPTION
Standardize some graph format for `src/iok` and also make `src/mdscraper` a client of the new changes. 

Copy pasta from the README in `src/iok`, here's a formal specification for our IoK data format. It's fully backwards compatible with what we have throughout our various projects currently. Further changes to data format will have to be coordinated, but this is a step in the right direction, regardless of whether or not we choose to refactor. #86.

```
{
    ...
    nodes: [
        data: {
            id: node_type == TOPIC ? sha256(data.name) : sha256(data.text || data.link),
            data: { # if node_type == RESOURCE
                text: <node_text>,
                link: <node_link>
            },
            name: <node_name>, # if node_type == TOPIC
            node_type: <node_type>,
            resource_type: <resource_type>, # if node_type == RESOURCE
            meta: ...,
        }
    ],
    edges: [
        data: {
            id: sha256(source || target),
            source: <source_node_id>,
            target: <target_node_id>,
            meta: ...,
        }
    ]
}
```

## Test

Added new unit tests in `src/iok` and update old ones in `src/mdscraper` (Scope object now updates an aggregate KnowledgeGraph). Also `mdscraper` runs as before: 

```
$ pipenv run python3 md_scrape.py https://raw.githubusercontent.com/sindresorhus/awesome/master/readme.md   
```

(Note: we can probably add this to Travis along with scraping IPFS as e2e test on Push/PR)


