### PR TITLE
Combine Unit Tests for both Markdown Scrapers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
     - stage: javascript-md-scraper
       language: node_js
       before_install: 
-      - pip install pipenv
+      - sudo pip3 install pipenv
       - pipenv install --dev
       - cd v4
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ jobs:
       python: 3.7
       script: "./build_and_test_scraper.sh"
     - stage: javascript-md-scraper
-      language: node_js
+      language: python
+      python: 3.7
       before_install: 
       - sudo pip3 install pipenv
       - pipenv install --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,10 @@ jobs:
       script: "./build_and_test_scraper.sh"
     - stage: javascript-md-scraper
       language: node_js
-      before_install: cd v4
+      before_install: 
+      - pip install pipenv
+      - pipenv install --dev
+      - cd v4
       script:
       - npm test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,10 @@ jobs:
     - stage: javascript-md-scraper
       language: python
       python: 3.7
-      before_install: 
+      install: 
       - sudo pip3 install pipenv
       - pipenv install --dev
+      before_script:
       - cd v4
       script:
       - npm test

--- a/src/iok/meta.py
+++ b/src/iok/meta.py
@@ -56,10 +56,10 @@ class KnowledgeGraph:
             del x["name"]
             del x["node_type"]
             del x["id"]
-        
-        del dat["directed"]        
-        del dat["graph"]        
-        del dat["multigraph"]        
+
+        del dat["directed"]
+        del dat["graph"]
+        del dat["multigraph"]
         if filename:
             with open(filename, "w") as f:
                 json.dump(dat, f)
@@ -128,7 +128,7 @@ class KnowledgeGraph:
         data = {"text": text, "link": link}
         if not id:
             m = hashlib.sha256()
-            input = name + json.dumps(data, separators=(',', ':'))
+            input = name + json.dumps(data, separators=(",", ":"))
             m.update(input.encode())
             id = m.hexdigest()
         return self._add_knowledge_node(

--- a/src/iok/meta.py
+++ b/src/iok/meta.py
@@ -56,7 +56,10 @@ class KnowledgeGraph:
             del x["name"]
             del x["node_type"]
             del x["id"]
-
+        
+        del dat["directed"]        
+        del dat["graph"]        
+        del dat["multigraph"]        
         if filename:
             with open(filename, "w") as f:
                 json.dump(dat, f)
@@ -121,14 +124,15 @@ class KnowledgeGraph:
         id: str = "",
         resource_type: Optional[ResourceType] = ResourceType.DESCRIPTION,
     ) -> str:
+        name = text[:10]
+        data = {"text": text, "link": link}
         if not id:
             m = hashlib.sha256()
-            m.update(text.encode())
-            m.update(link.encode())
+            input = name + json.dumps(data, separators=(',', ':'))
+            m.update(input.encode())
             id = m.hexdigest()
-        data = {"text": text, "link": link}
         return self._add_knowledge_node(
-            NodeType.RESOURCE, id=id, data=data, resource_type=resource_type
+            NodeType.RESOURCE, id=id, name=name, data=data, resource_type=resource_type
         )
 
     def _add_knowledge_node(
@@ -146,7 +150,8 @@ class KnowledgeGraph:
         elif node_type == NodeType.RESOURCE:
             self.graph.add_node(
                 id,
-                name=f"res-{id[:7]}",  # XXX: get rid of this eventually
+                # name=f"res-{id[:7]}",  # XXX: get rid of this eventually
+                name=data["text"][:10],
                 data=data,
                 resource_type=resource_type,
                 node_type=node_type,

--- a/src/mdscraper/__main__.py
+++ b/src/mdscraper/__main__.py
@@ -1,0 +1,25 @@
+import sys
+import json
+from .md_scrape import graphFromText, main
+
+# configs
+JSON_FILE = "graph.json"
+GRAPH_FILE = "graph.png"
+
+if len(sys.argv) < 2:
+    print("Missing link argument")
+    print("Expected: md_scrape <raw md link>")
+    print(
+        "Example: md_scrape https://raw.githubusercontent.com/rustielin/iok/master/README.md"
+    )
+    exit(1)
+
+if (str(sys.argv[1])[0]=='-'):
+    print(json.dumps(graphFromText(sys.stdin.read()).write_to_json()))
+else:
+    link = sys.argv[1]
+    g = main(link)
+
+    # draw to file for debugging
+    g.write_graph(GRAPH_FILE)
+    g.write_to_json(JSON_FILE)

--- a/src/mdscraper/__main__.py
+++ b/src/mdscraper/__main__.py
@@ -14,7 +14,7 @@ if len(sys.argv) < 2:
     )
     exit(1)
 
-if (str(sys.argv[1])[0]=='-'):
+if str(sys.argv[1])[0] == "-":
     print(json.dumps(graphFromText(sys.stdin.read()).write_to_json()))
 else:
     link = sys.argv[1]

--- a/src/mdscraper/md_scrape.py
+++ b/src/mdscraper/md_scrape.py
@@ -149,20 +149,17 @@ def match_line(match: str, line: str, scopes: list, graph: KnowledgeGraph) -> li
 
 
 def graphFromText(text: str):
-  textlines = text.splitlines()
-  scopes = []
-  graph = KnowledgeGraph(0)
-  for line in textlines:
-      match = match_hierarchy(line)
-      scopes = match_line(match, line, scopes, graph)
-  return graph
+    textlines = text.splitlines()
+    scopes = []
+    graph = KnowledgeGraph(0)
+    for line in textlines:
+        match = match_hierarchy(line)
+        scopes = match_line(match, line, scopes, graph)
+    return graph
+
 
 # returns the graph for debugging
 def main(link: str) -> KnowledgeGraph:
     f = requests.get(link)
     text = f.text
     return graphFromText(text)
-
-
-
-    

--- a/src/mdscraper/md_scrape.py
+++ b/src/mdscraper/md_scrape.py
@@ -8,13 +8,8 @@ import requests
 import matplotlib.pyplot as plt
 from hashlib import sha256
 import json
-import sys
 import uuid
 from networkx.readwrite import json_graph
-
-# configs
-JSON_FILE = "graph.json"
-GRAPH_FILE = "graph.png"
 
 # regex for ordering lines based on hierarchy
 HIERARCHY = [r"^[*-]", r"^[A-Za-z]", r"^###", r"^##", r"^#"]
@@ -153,35 +148,21 @@ def match_line(match: str, line: str, scopes: list, graph: KnowledgeGraph) -> li
             return scopes_cpy
 
 
+def graphFromText(text: str):
+  textlines = text.splitlines()
+  scopes = []
+  graph = KnowledgeGraph(0)
+  for line in textlines:
+      match = match_hierarchy(line)
+      scopes = match_line(match, line, scopes, graph)
+  return graph
+
 # returns the graph for debugging
 def main(link: str) -> KnowledgeGraph:
-
     f = requests.get(link)
     text = f.text
-    textlines = text.splitlines()
-
-    scopes = []
-    graph = KnowledgeGraph(0)
-    for line in textlines:
-        match = match_hierarchy(line)
-        scopes = match_line(match, line, scopes, graph)
-
-    return graph
+    return graphFromText(text)
 
 
-if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("Missing link argument")
-        print("Expected: md_scrape <raw md link>")
-        print(
-            "Example: md_scrape https://raw.githubusercontent.com/rustielin/iok/master/README.md"
-        )
-        exit(1)
 
-    link = sys.argv[1]
-    g = main(link)
-
-    # draw to file for debugging
-    g.write_graph(GRAPH_FILE)
-
-    g.write_to_json(JSON_FILE)
+    

--- a/v4/src/md_scraper.js
+++ b/v4/src/md_scraper.js
@@ -28,7 +28,7 @@ class Scope {
 
     // create id
     const hash = sha256.create();
-    hash.update(JSON.stringify(this.node));
+    hash.update(this.node.name + (JSON.stringify(this.data) || ''));
     this.node.id = this.id = hash.hex(); // eslint-disable-line
 
     // set level for comparing hierarchy
@@ -61,7 +61,7 @@ function updateScopes(newScope, scopes, graph) {
   // eslint-disable-next-line
   let scopesCpy = [...scopes];
 
-  graph.nodes.push(newScope.node);
+  graph.nodes.push({ data: newScope.node });
   // console.log("Adding ", new_scope.node, "\n")
 
   if (scopesCpy.length) {
@@ -73,9 +73,11 @@ function updateScopes(newScope, scopes, graph) {
 
     graph.edges.push(
       {
-        source: newScope.id,
-        target: targetId,
-        id: hash.hex(),
+        data: {
+          source: newScope.id,
+          target: targetId,
+          id: hash.hex(),
+        }
       },
     );
   }

--- a/v4/src/md_scraper.js
+++ b/v4/src/md_scraper.js
@@ -77,7 +77,7 @@ function updateScopes(newScope, scopes, graph) {
           source: newScope.id,
           target: targetId,
           id: hash.hex(),
-        }
+        },
       },
     );
   }
@@ -137,7 +137,7 @@ export function graphFromUrl(link) {
   return g;
 }
 
-export function graphFromText(text) {
+export function jsGraphFromText(text) {
   const g = createGraph(text);
   // console.log(JSON.stringify(g, null, 2));
   return g;

--- a/v4/src/md_scraper.test.js
+++ b/v4/src/md_scraper.test.js
@@ -1,15 +1,18 @@
 import { graphFromText } from './md_scraper'; // eslint-disable-line
+import childProcess from 'child_process';
+
+const wrapData = (x) => ({ data: x })
 
 function createTestNode(nodeType, name, id, resType, text, link) {
   if (nodeType === 1) {
-    return {
+    return wrapData({
       id: expect.toStartWith(id),
       name,
       node_type: nodeType,
-    };
+    });
   }
   if (nodeType === 2) {
-    return {
+    return wrapData({
       data: {
         text, link,
       },
@@ -17,22 +20,23 @@ function createTestNode(nodeType, name, id, resType, text, link) {
       name,
       node_type: nodeType,
       resource_type: resType,
-    };
+    });
   }
   return null;
 }
 
 function createTestEdge(id, source, target) {
-  return {
+  return wrapData({
     id: expect.toStartWith(id),
     source: expect.toStartWith(source),
     target: expect.toStartWith(target),
-  };
+  });
 }
 
 // compare just the beginning for id hashes
 expect.extend({
   toStartWith(received, beginning) {
+    if (beginning.length != 10) console.error(`${beginning} is length ${beginning.length}, not 10`)
     return {
       message: () => `${received} should equal ${beginning}`,
       pass: beginning.slice(0, 10) === (received.slice(0, 10)),
@@ -40,100 +44,130 @@ expect.extend({
   },
 });
 
+function pyGraphFromText(text) {
+  const output = childProcess.spawnSync(
+    'pipenv',
+    ['run', 'python3', '-m', 'mdscraper', '-'],
+    {
+      cwd: __dirname + '/../../src',
+      input: text
+    }
+  );
+  if (output.status != 0) {
+    throw new Error('Python processes exited with code ' + output.status
+      + ' and error message ' + output.error + '. stderr was ' + output.stderr);
+  }
+  return JSON.parse(output.stdout.toString());
+}
+
 // Tests
-describe('markdown scraper', () => {
-  it('should parse an empty markdown', () => {
-    expect(graphFromText('')).toEqual({
-      nodes: [],
-      edges: [],
+function testMarkdownScraper(name, graphFromText) {
+  describe(name, () => {
+    it('should parse an empty markdown', () => {
+      expect(graphFromText('')).toEqual({
+        nodes: [],
+        edges: [],
+      });
     });
-  });
 
-  it('only description resource nodes', () => {
-    expect(graphFromText('- FirstRes \n-SecondRes \nThirdRes')).toEqual({
-      nodes: [
-        createTestNode(2, 'FirstRes', '1e71a7e10dd511b4937b4de28', 1, 'FirstRes', ''),
-        createTestNode(2, 'SecondRes', '4faea3d4eb412cea485e9e70', 1, 'SecondRes', ''),
-        createTestNode(2, 'ThirdRes', 'c0dd146d647e4eeded368dcae', 1, 'ThirdRes', ''),
-      ],
-      edges: [],
+    it('should parse a single node', () => {
+      expect(graphFromText('Node')).toEqual({
+        nodes: [
+          createTestNode(2, 'Node', '7ab42597ae', 1, 'Node', ''),
+        ],
+        edges: [],
+      });
     });
-  });
 
-  it('only link resource nodes', () => {
-    expect(graphFromText(
-      `- [linkTitle1](insertLink1) extra
-      \n- [linkTitle2](insertLink2) extra text
-      \n- [linkTitle3](insertLink3) extra text idk`,
-    )).toEqual({
-      nodes: [
-        createTestNode(2, 'linkTitle1', '40f38118359d044116aa7954b8c223b', 2, 'linkTitle1', 'insertLink1'),
-        createTestNode(2, 'linkTitle2', '4b9abb860dda2bc8fa41e2ed036c7fa', 2, 'linkTitle2', 'insertLink2'),
-        createTestNode(2, 'linkTitle3', '8dfd191644db73fe0aebf493432ec81', 2, 'linkTitle3', 'insertLink3'),
-      ],
-      edges: [],
+    it('only description resource nodes', () => {
+      expect(graphFromText('- FirstRes \n-SecondRes \nThirdRes')).toEqual({
+        nodes: [
+          createTestNode(2, 'FirstRes', '8a16879556', 1, 'FirstRes', ''),
+          createTestNode(2, 'SecondRes', 'cded3d6d39', 1, 'SecondRes', ''),
+          createTestNode(2, 'ThirdRes', '1a35511639', 1, 'ThirdRes', ''),
+        ],
+        edges: [],
+      });
     });
-  });
 
-  it('only same level topic nodes', () => {
-    expect(graphFromText('# First Topic \n# Second Topic \n# Third Topic')).toEqual({
-      nodes: [
-        createTestNode(1, 'First Topic', 'e00194285639baedc6dc17', null, null, null),
-        createTestNode(1, 'Second Topic', '6890869a8baf91bbf01ef', null, null, null),
-        createTestNode(1, 'Third Topic', 'dcd9cbfb54e9dbcff2', null, null, null),
-      ],
-      edges: [],
+    it('only link resource nodes', () => {
+      expect(graphFromText(
+        `- [linkTitle1](insertLink1) extra
+        \n- [linkTitle2](insertLink2) extra text
+        \n- [linkTitle3](insertLink3) extra text idk`,
+      )).toEqual({
+        nodes: [
+          createTestNode(2, 'linkTitle1', 'dbb99b9f85', 2, 'linkTitle1', 'insertLink1'),
+          createTestNode(2, 'linkTitle2', 'c655b93dff', 2, 'linkTitle2', 'insertLink2'),
+          createTestNode(2, 'linkTitle3', '55cc6a45ea', 2, 'linkTitle3', 'insertLink3'),
+        ],
+        edges: [],
+      });
     });
-  });
 
-  it('same (higher) level topic nodes', () => {
-    expect(graphFromText('### First Topic \n### Second Topic \n### Third Topic')).toEqual({
-      nodes: [
-        createTestNode(1, 'First Topic', 'e00194285639baedc6dc1', null, null, null),
-        createTestNode(1, 'Second Topic', '6890869a8baf91bbf01e', null, null, null),
-        createTestNode(1, 'Third Topic', 'dcd9cbfb54e9dbcff2', null, null, null),
-      ],
-      edges: [],
+    it('only same level topic nodes', () => {
+      expect(graphFromText('# First Topic \n# Second Topic \n# Third Topic')).toEqual({
+        nodes: [
+          createTestNode(1, 'First Topic', 'fc56b16568', null, null, null),
+          createTestNode(1, 'Second Topic', 'faeb199ae3', null, null, null),
+          createTestNode(1, 'Third Topic', '00006a770b', null, null, null),
+        ],
+        edges: [],
+      });
     });
-  });
 
-  it('nested topic nodes', () => {
-    expect(graphFromText(
-      '# First Topic \n# SecondTopic \n## Second Topic Nested \n### Second Topic Nested Nested \n# Third Topic',
-    )).toEqual({
-      nodes: [
-        createTestNode(1, 'First Topic', 'e00194285639baedc6dc1785038', null, null, null),
-        createTestNode(1, 'SecondTopic', 'e211c01f4db8f6727eb99275b69d646ece', null, null, null),
-        createTestNode(1, 'Second Topic Nested', '7f6a3d4c56d4201bb2fcda0f1b7', null, null, null),
-        createTestNode(1, 'Second Topic Nested Nested', 'b786e851cddca7fa4379f', null, null, null),
-        createTestNode(1, 'Third Topic', 'dcd9cbfb54e9dbcff23b828abf4d5382', null, null, null),
-      ],
-      edges: [
-        createTestEdge('44b392290a2160bcf4', '7f6a3d4c56d4201bb2f', 'e211c01f4db8f6727eb99275b'),
-        createTestEdge('acee519799f614a9d6', 'b786e851cddca7fa437', '7f6a3d4c56d4201bb2fcda0f1'),
-      ],
+    it('same (higher) level topic nodes', () => {
+      expect(graphFromText('### First Topic \n### Second Topic \n### Third Topic')).toEqual({
+        nodes: [
+          createTestNode(1, 'First Topic', 'fc56b16568', null, null, null),
+          createTestNode(1, 'Second Topic', 'faeb199ae3', null, null, null),
+          createTestNode(1, 'Third Topic', '00006a770b', null, null, null),
+        ],
+        edges: [],
+      });
     });
-  });
 
-  it('mix of resource and topic nodes', () => {
-    expect(graphFromText(
-      `# Topic1 \n- [Topic1ResLink](Link1)
-      \n## Topic2 \n- Topic2ResDesc 
-      \n## Topic2Nested`,
-    )).toEqual({
-      nodes: [
-        createTestNode(1, 'Topic1', 'ddc41a6256b8d5582119ff7b4b702d5', null, null, null),
-        createTestNode(2, 'Topic1ResL', '9d631c4a21315dafc31e8b15c47d', 2, 'Topic1ResLink', 'Link1'),
-        createTestNode(1, 'Topic2', '508f75c1fd41d83b3a09121502965e8d', null, null, null),
-        createTestNode(2, 'Topic2ResD', '85388daed79a483b01c67', 1, 'Topic2ResDesc', ''),
-        createTestNode(1, 'Topic2Nested', '8a95cfed41193f52443d0d5782b', null, null, null),
-      ],
-      edges: [
-        createTestEdge('855b63c2a3f3d9c2fdc620fdb68', '9d631c4a21315dafc31e8b15c4', 'ddc41a6256b8d5582119ff7b'),
-        createTestEdge('3902a3caa209498566943ed8aca', '508f75c1fd41d83b3a09121502', 'ddc41a6256b8d5582119ff7b'),
-        createTestEdge('53d69247e0eae30dd3381af564e', '85388daed79a483b01c67b742a', '508f75c1fd41d83b3a091215'),
-        createTestEdge('b0ebf88195fe7ea87b07bd26e3e', '8a95cfed41193f52443d0d5782', 'ddc41a6256b8d5582119ff7b'),
-      ],
+    it('nested topic nodes', () => {
+      expect(graphFromText(
+        '# First Topic \n# SecondTopic \n## Second Topic Nested \n### Second Topic Nested Nested \n# Third Topic',
+      )).toEqual({
+        nodes: [
+          createTestNode(1, 'First Topic', 'fc56b16568', null, null, null),
+          createTestNode(1, 'SecondTopic', '6763fa83c2', null, null, null),
+          createTestNode(1, 'Second Topic Nested', '4d5775b756', null, null, null),
+          createTestNode(1, 'Second Topic Nested Nested', '1b5e1a9bf8', null, null, null),
+          createTestNode(1, 'Third Topic', '00006a770b', null, null, null),
+        ],
+        edges: [
+          createTestEdge('10f8d7bc5f', '4d5775b756', '6763fa83c2'),
+          createTestEdge('8c9f06a735', '1b5e1a9bf8', '4d5775b756'),
+        ],
+      });
+    });
+
+    it('mix of resource and topic nodes', () => {
+      expect(graphFromText(
+        `# Topic1 \n- [Topic1ResLink](Link1)
+        \n## Topic2 \n- Topic2ResDesc 
+        \n## Topic2Nested`,
+      )).toEqual({
+        nodes: [
+          createTestNode(1, 'Topic1', 'd59f7ae6a9', null, null, null),
+          createTestNode(2, 'Topic1ResL', '4e380a6f1e', 2, 'Topic1ResLink', 'Link1'),
+          createTestNode(1, 'Topic2', '95d5b9038c', null, null, null),
+          createTestNode(2, 'Topic2ResD', '1c0b28ed7c', 1, 'Topic2ResDesc', ''),
+          createTestNode(1, 'Topic2Nested', '7dc5f5a8d8', null, null, null),
+        ],
+        edges: [
+          createTestEdge('1e646b414d', '4e380a6f1e', 'd59f7ae6a9'),
+          createTestEdge('ef3c796c13', '95d5b9038c', 'd59f7ae6a9'),
+          createTestEdge('673fe87639', '1c0b28ed7c', '95d5b9038c'),
+          createTestEdge('07c7bdfba8', '7dc5f5a8d8', 'd59f7ae6a9'),
+        ],
+      });
     });
   });
-});
+}
+
+testMarkdownScraper('Javascript markdown scraper', graphFromText);
+testMarkdownScraper('Python markdown scraper', pyGraphFromText);

--- a/v4/src/md_scraper.test.js
+++ b/v4/src/md_scraper.test.js
@@ -1,7 +1,8 @@
-import { graphFromText } from './md_scraper'; // eslint-disable-line
-import childProcess from 'child_process';
+import childProcess from 'child_process'; // eslint-disable-line
+import { jsGraphFromText } from './md_scraper'; // eslint-disable-line
 
-const wrapData = (x) => ({ data: x })
+const wrapData = (x) => ({ data: x });
+const path = require('path');
 
 function createTestNode(nodeType, name, id, resType, text, link) {
   if (nodeType === 1) {
@@ -36,7 +37,7 @@ function createTestEdge(id, source, target) {
 // compare just the beginning for id hashes
 expect.extend({
   toStartWith(received, beginning) {
-    if (beginning.length != 10) console.error(`${beginning} is length ${beginning.length}, not 10`)
+    // if (beginning.length !== 10) console.error(`${beginning} is length ${beginning.length}`)
     return {
       message: () => `${received} should equal ${beginning}`,
       pass: beginning.slice(0, 10) === (received.slice(0, 10)),
@@ -49,13 +50,13 @@ function pyGraphFromText(text) {
     'pipenv',
     ['run', 'python3', '-m', 'mdscraper', '-'],
     {
-      cwd: __dirname + '/../../src',
-      input: text
-    }
+      cwd: path.join(__dirname, '/../../src'),
+      input: text,
+    },
   );
-  if (output.status != 0) {
-    throw new Error('Python processes exited with code ' + output.status
-      + ' and error message ' + output.error + '. stderr was ' + output.stderr);
+  if (output.status !== 0) {
+    throw new Error(`Python processes exited with code ${output.status}
+      and error message ${output.error}. stderr was ${output.stderr}`);
   }
   return JSON.parse(output.stdout.toString());
 }
@@ -169,5 +170,5 @@ function testMarkdownScraper(name, graphFromText) {
   });
 }
 
-testMarkdownScraper('Javascript markdown scraper', graphFromText);
+testMarkdownScraper('Javascript markdown scraper', jsGraphFromText);
 testMarkdownScraper('Python markdown scraper', pyGraphFromText);


### PR DESCRIPTION
### In this PR

- make it so the javascript jest tests for markdown scrapers runs for both the python and javascript scrapers
- altered the way node id's are calculated / hashed for it to work