### PR TITLE
[v4][storage] fix and clean storage params

### DIFF
--- a/v4/src/App.jsx
+++ b/v4/src/App.jsx
@@ -8,57 +8,13 @@ import Landing from './Landing';
 import SignedIn from './SignedIn';
 import Log from './log';
 import { STORAGE_TYPES } from './types';
-import { DEFL_STORAGE, DEFL_STORAGE_OPTIONS } from './constants';
+import { parseParams, redirectGuest, redirectStorage } from './urlUtils';
 
 class App extends Component {
-  static changeToGuestMode() {
-    const url = new URL(window.location.href);
-    const par = url.searchParams;
-    par.set('guest', 'true');
-    window.location.href = url;
-  }
-
-  static parseParams() {
-    const par = new URLSearchParams(window.location.search);
-
-    /**
-     * Params parsing logic, mainly for configuring storage
-     * and related options
-     * */
-    let storage = DEFL_STORAGE;
-    let options = JSON.parse(JSON.stringify(DEFL_STORAGE_OPTIONS));
-    if (par.has('storage')) {
-      switch (par.get('storage')) {
-        case STORAGE_TYPES.BLOCKSTACK:
-          storage = STORAGE_TYPES.BLOCKSTACK;
-          if (par.has('guest') && par.get('guest') === 'true') {
-            options.guest = true;
-            options.username = 'guest';
-          } else {
-            options.guest = false;
-          }
-          if (par.has('loaduser')) {
-            options.loaduser = par.get('loaduser');
-          }
-          break;
-        case STORAGE_TYPES.IPFS:
-          storage = STORAGE_TYPES.IPFS;
-          if (par.has('hash')) {
-            options.hash = par.get('hash');
-          }
-          break;
-        default:
-          storage = DEFL_STORAGE;
-          options = JSON.parse(JSON.stringify(DEFL_STORAGE_OPTIONS));
-      }
-    }
-    return { storage, options };
-  }
-
   constructor() {
     super();
 
-    const { storage, options } = App.parseParams();
+    const { storage, options } = parseParams();
     this.state = { storage, options };
     this.userSession = new UserSession();
 
@@ -69,21 +25,19 @@ class App extends Component {
     const { storage, options } = this.state;
     const session = this.userSession;
 
-    // If we're using blockstack, get the username
+    // If we're using blockstack authed, get the username
     if (storage === STORAGE_TYPES.BLOCKSTACK
       && !('guest' in options)
-      && !('loaduser' in options)
-      && !options.guest
-      && !options.loaduser
-      && !session.isUserSignedIn()
-      && session.isSignInPending()) {
-      session.handlePendingSignIn().then((userData) => {
-        if (!userData.username) {
-          throw new Error('This app requires a username.');
-        }
-        this.setState({ options: { ...options, username: userData.username } });
-        window.location.href = '/';
-      });
+      && !options.guest) {
+      if (!session.isUserSignedIn() && session.isSignInPending()) {
+        session.handlePendingSignIn().then((userData) => {
+          if (!userData.username) {
+            throw new Error('This app requires a username.');
+          }
+          this.setState({ options: { ...options, username: userData.username } });
+          redirectStorage(STORAGE_TYPES.BLOCKSTACK, { loaduser: userData.username });
+        });
+      }
     }
   }
 
@@ -95,7 +49,7 @@ class App extends Component {
         {storage === STORAGE_TYPES.IPFS || options.guest || this.userSession.isUserSignedIn() ? (
           <SignedIn storage={storage} options={options} />
         ) : (
-          <Landing guestModeHandler={App.changeToGuestMode} />
+          <Landing guestModeHandler={redirectGuest} />
         )}
       </div>
     );

--- a/v4/src/NavBar.jsx
+++ b/v4/src/NavBar.jsx
@@ -5,29 +5,17 @@ import { Link } from 'react-router-dom';
 import { PropTypes } from 'prop-types';
 import { STORAGE_TYPES } from './types';
 import { DEFL_STORAGE, DEFL_STORAGE_OPTIONS } from './constants';
+import { redirectStorage, redirectDefl } from './urlUtils';
 import './styles/NavBar.css';
 
 class NavBar extends Component {
-  static paramsBuilder(options) {
-    let str = '/';
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const key in options) {
-      if (str !== '') {
-        str += '&';
-      }
-      str += `${key}=${encodeURIComponent(options[key])}`;
-    }
-    return str;
-  }
-
   static onHomeClick(storage, options, changeLoadUser) {
     switch (storage) {
       case STORAGE_TYPES.BLOCKSTACK:
         changeLoadUser(options.username);
         break;
       case STORAGE_TYPES.IPFS:
-        window.location.href = NavBar.paramsBuilder(DEFL_STORAGE_OPTIONS);
+        redirectDefl();
         break;
       default:
         break;
@@ -73,7 +61,7 @@ class NavBar extends Component {
           <button
             type="button"
             className="btn btn-info btn-lg btn-util"
-            onClick={() => { window.location.href = '/?storage='.concat(STORAGE_TYPES.IPFS); }}
+            onClick={() => redirectStorage(STORAGE_TYPES.IPFS)}
           >
             Try IPFS!
           </button>
@@ -83,7 +71,7 @@ class NavBar extends Component {
           <button
             type="button"
             className="btn btn-info btn-lg btn-util"
-            onClick={() => { window.location.href = '/?storage='.concat(STORAGE_TYPES.BLOCKSTACK); }}
+            onClick={() => redirectStorage(STORAGE_TYPES.BLOCKSTACK)}
           >
             Try Blockstack!
           </button>

--- a/v4/src/urlUtils.js
+++ b/v4/src/urlUtils.js
@@ -1,0 +1,62 @@
+import { STORAGE_TYPES } from './types';
+import { DEFL_STORAGE, DEFL_STORAGE_OPTIONS } from './constants';
+
+
+export const redirectStorage = (storage, options = {}) => {
+  const url = new URL(window.location.origin);
+  url.pathname = storage;
+  const par = url.searchParams;
+  Object.keys(options).forEach((key) => {
+    par.set(key, options[key]);
+  });
+  window.location.href = url;
+};
+
+export const redirectGuest = () => {
+  redirectStorage(STORAGE_TYPES.BLOCKSTACK, { guest: true });
+};
+
+export const redirectDefl = () => {
+  redirectStorage(DEFL_STORAGE, DEFL_STORAGE_OPTIONS);
+};
+
+export const parseParams = () => {
+  const url = new URL(window.location.href);
+  // hacky, but gets the pathname without params
+  const pathname = url.pathname.split('/')[1].split('&')[0];
+  const par = new URLSearchParams(window.location.search);
+
+  /**
+       * Params parsing logic, mainly for configuring storage
+       * and related options. Anything invalid goes to default
+       * TODO: hide this from url params (#102)
+       * */
+  let storage = DEFL_STORAGE;
+  const options = JSON.parse(JSON.stringify(DEFL_STORAGE_OPTIONS));
+  switch (pathname) {
+    case STORAGE_TYPES.BLOCKSTACK:
+      storage = STORAGE_TYPES.BLOCKSTACK;
+      if (par.has('guest') && par.get('guest') === 'true') {
+        options.guest = true;
+        options.username = 'guest';
+      } else {
+        options.guest = false;
+      }
+      if (par.has('loaduser')) {
+        options.loaduser = par.get('loaduser');
+      }
+      break;
+    case STORAGE_TYPES.IPFS:
+      storage = STORAGE_TYPES.IPFS;
+      if (par.has('hash')) {
+        options.hash = par.get('hash');
+      } else {
+        redirectDefl();
+      }
+      break;
+    default:
+      redirectDefl();
+  }
+
+  return { storage, options };
+};


### PR DESCRIPTION
Clean up the way we construct, parse, and redirect based on URL params. This is not really best practice, but makes our URLs more shareable.
* major change to use storage type as URL pathname rather than as a search param, since they will be required
* add general url utils 
* redirect default when invalid URL specified

Also resolves #79 